### PR TITLE
Add option to loop until the next notification is received

### DIFF
--- a/bin/zencoder_fetcher
+++ b/bin/zencoder_fetcher
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 require File.expand_path(File.dirname(__FILE__) + '/../lib/zencoder_fetcher.rb')
+require File.expand_path(File.dirname(__FILE__) + '/../lib/zencoder_fetcher_version.rb')
 require 'trollop'
 
 #
@@ -64,6 +65,7 @@ begin
       puts "Checking Zencoder for Notifications" << (@since ? " since #{@since.utc.strftime('%b %e, %Y @ %H:%M:%S %Z')}" : "")
       options.merge!(:since => @since)
       @since = ZencoderFetcher.request(options)
+      break if @since == true
       sleep [10, opts[:interval]].max
     end
   else

--- a/bin/zencoder_fetcher
+++ b/bin/zencoder_fetcher
@@ -25,6 +25,7 @@ EOS
   opt :since, "Load notifications starting since _n_ minutes ago.", :short => 'm', :type => Integer, :default => nil
   opt :endpoint, "Zencoder endpoint to use. Defaults to https://app.zencoder.com/.", :short => 'e', :type => String
   opt :api_version, "API version to use.", :short => 'v', :type => String, :default => 'v2'
+  opt :next, "Loops until a new notification arrives. This overrides --loop, --count (with 1) and --since (with 0)", :short => 'x', :default => false
 end
 
 
@@ -44,10 +45,15 @@ EOS
   exit 1
 end
 
-
 #
 # Run Zencoder Notifier
 #
+
+if opts[:next]
+  opts[:loop] = true
+  opts[:count] = 1
+  opts[:since] = 0
+end
 
 options               = {}
 options[:api_key]     = ARGV[0]
@@ -57,6 +63,7 @@ options[:page]        = opts[:page]
 options[:since]       = (opts[:since] && (Time.now.utc - (opts[:since].to_i * 60))) || nil
 options[:endpoint]    = opts[:endpoint]
 options[:api_version] = opts[:api_version]
+options[:next]        = opts[:next]
 
 begin
   if opts[:loop]

--- a/lib/zencoder_fetcher.rb
+++ b/lib/zencoder_fetcher.rb
@@ -51,7 +51,7 @@ module ZencoderFetcher
         options = options.merge({:basic_auth => auth}) if !auth.empty?
         begin
           HTTParty.post(local_url, options)
-        rescue Errno::ECONNREFUSED => e
+        rescue Errno::ECONNREFUSED
           puts "Unable to connect to your local server at #{local_url}. Is it running?"
           raise FetcherLocalConnectionError
         end

--- a/lib/zencoder_fetcher.rb
+++ b/lib/zencoder_fetcher.rb
@@ -33,7 +33,7 @@ module ZencoderFetcher
       puts "Notifications retrieved: #{response["notifications"].size}"
       if response["notifications"].size > 0
         puts "Posting to #{local_url}"
-        single_notification = true
+        single_notification = true if options[:next]
       end
       response["notifications"].each do |notification|
         format = notification.delete("format")
@@ -54,7 +54,7 @@ module ZencoderFetcher
         options = options.merge({:basic_auth => auth}) if !auth.empty?
         begin
           HTTParty.post(local_url, options)
-          return true if single_notification
+          raise SystemExit if single_notification
         rescue Errno::ECONNREFUSED
           puts "Unable to connect to your local server at #{local_url}. Is it running?"
           raise FetcherLocalConnectionError

--- a/lib/zencoder_fetcher.rb
+++ b/lib/zencoder_fetcher.rb
@@ -31,7 +31,10 @@ module ZencoderFetcher
       raise FetcherError
     else
       puts "Notifications retrieved: #{response["notifications"].size}"
-      puts "Posting to #{local_url}" if response["notifications"].size > 0
+      if response["notifications"].size > 0
+        puts "Posting to #{local_url}"
+        single_notification = true
+      end
       response["notifications"].each do |notification|
         format = notification.delete("format")
         if format == "xml"
@@ -51,6 +54,7 @@ module ZencoderFetcher
         options = options.merge({:basic_auth => auth}) if !auth.empty?
         begin
           HTTParty.post(local_url, options)
+          return true if single_notification
         rescue Errno::ECONNREFUSED
           puts "Unable to connect to your local server at #{local_url}. Is it running?"
           raise FetcherLocalConnectionError

--- a/lib/zencoder_fetcher.rb
+++ b/lib/zencoder_fetcher.rb
@@ -9,12 +9,6 @@ rescue
 end
 
 module ZencoderFetcher
-  FETCHER_VERSION = [0,2,8] unless defined?(FETCHER_VERSION)
-
-  def self.version
-    FETCHER_VERSION.join(".")
-  end
-
   def self.request(options={})
     query = {
       "api_key"  => options[:api_key],

--- a/lib/zencoder_fetcher_version.rb
+++ b/lib/zencoder_fetcher_version.rb
@@ -1,0 +1,8 @@
+module ZencoderFetcher
+  FETCHER_VERSION = [0,2,8] unless defined?(FETCHER_VERSION)
+
+  def self.version
+    FETCHER_VERSION.join(".")
+  end
+end
+

--- a/zencoder-fetcher.gemspec
+++ b/zencoder-fetcher.gemspec
@@ -2,7 +2,7 @@
 lib = File.expand_path('../lib/', __FILE__)
 $:.unshift lib unless $:.include?(lib)
 
-require 'zencoder_fetcher'
+require 'zencoder_fetcher_version'
 
 Gem::Specification.new do |s|
   s.name          = "zencoder-fetcher"


### PR DESCRIPTION
This PR modifies two things:
- Move the version into the `zencoder_fetcher_version.rb` file
- Add a new `next` option, which overrides some of the other options (namely `loop`, `count` and `since`) which will keep the program running until a new notification is fetched.
